### PR TITLE
Updated board profile to properly create firmware binaries.

### DIFF
--- a/mpconfigboard.mk
+++ b/mpconfigboard.mk
@@ -1,4 +1,6 @@
 MCU_SERIES = f4
 CMSIS_MCU = STM32F407xx
 AF_FILE = boards/stm32f405_af.csv
-LD_FILE = boards/stm32f405.ld
+LD_FILES = boards/stm32f405.ld boards/common_ifs.ld
+TEXT0_ADDR = 0x08000000
+TEXT1_ADDR = 0x08020000


### PR DESCRIPTION
With this patch the firmware builds correctly, however you have to run "make" twice.  I suspect that when running make against a virgin directory, the newer timestamps for the STM32_HAL repository, which is pulled after "make" has started, cause make to initially skip the build.

If I have time to figure out a fix, I'll submit a new pull request.  For now I'm happy to have a working MicroPython binary.

Thanks again!