### PR TITLE
Enable SD Card

### DIFF
--- a/mpconfigboard.h
+++ b/mpconfigboard.h
@@ -7,7 +7,7 @@
 #define MICROPY_HW_ENABLE_RTC       (1)
 #define MICROPY_HW_ENABLE_DAC       (1)
 #define MICROPY_HW_ENABLE_USB       (1)
-#define MICROPY_HW_ENABLE_SDCARD    (0)		// it has a sd scard, but i am not sure what the detect pin is, yet
+#define MICROPY_HW_ENABLE_SDCARD    (1)		// it has a sd scard, but no detect pin
 
 // HSE is 8MHz
 #define MICROPY_HW_CLK_PLLM (8) // divide external clock by this to get 1MHz


### PR DESCRIPTION
Enable SD Card. Since my pull request was merged upstream (see https://github.com/micropython/micropython/pull/5185#event-2701488861), I suggest to enable the SD card. I tried, it works:

```
MicroPython v1.11-423-g06ae818f9 on 2019-10-10; MCUDEV STM32F407VE with STM32F407VE
Type "help()" for more information.
>>> import os
>>> os.listdir()
['System Volume Information', 'a.z80', 'virsynth.z80', 'Fearzone48_2018.z80', 'AYTracker.z80', 'Melody Master.z80',..., 'ZX Poker.z80']
```